### PR TITLE
#13 Dodanie endpointu zwracającego liste obiektów sportowych dla strony głownej

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -9,6 +9,7 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	sourceCompatibility = '21'
+//	targetCompatibility = '21'
 }
 
 repositories {
@@ -22,9 +23,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.projectlombok:lombok:1.18.28'
+//	implementation group: 'org.mapstruct', name: 'mapstruct-processor', version: '1.5.5.Final'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	runtimeOnly 'org.postgresql:postgresql'
-	compileOnly 'org.projectlombok:lombok:0.11.0'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 }
 
 tasks.named('test') {

--- a/backend/initdb/01-schema.sql
+++ b/backend/initdb/01-schema.sql
@@ -9,12 +9,13 @@ CREATE TABLE address (
 
 CREATE TABLE sport_complexes (
                         id SERIAL PRIMARY KEY,
-                        name CHAR(255) NOT NULL,
+                        name VARCHAR(255) NOT NULL,
                         description TEXT,
                         website VARCHAR(255),
                         surface VARCHAR(255),
                         category VARCHAR(255),
-                        coordinates VARCHAR(255),
+                        latitude DECIMAL(8,6),
+                        longitude DECIMAL(9,6),
                         address_id INT NOT NULL,
                         open_24_7 BOOLEAN,
                         FOREIGN KEY (address_id) REFERENCES address(id)
@@ -33,7 +34,6 @@ CREATE TABLE events (
                        id SERIAL PRIMARY KEY,
                        description TEXT,
                        sport_complex_id INT NOT NULL,
-                       category VARCHAR(255),
                        start_time TIMESTAMP,
                        end_time TIMESTAMP,
                        FOREIGN KEY (sport_complex_id) REFERENCES sport_complexes(id)

--- a/backend/initdb/02-random-data.sql
+++ b/backend/initdb/02-random-data.sql
@@ -1,0 +1,55 @@
+INSERT INTO address (street, postal_code, building_number, apartment_number, city)
+VALUES ('123 Maple Street', '12345', '10', '2A', 'Springfield'),
+       ('456 Oak Avenue', '67890', '20', '3B', 'Greenville'),
+       ('456 Oak Street', '45321', '20', '3B', 'Springfield'),
+       ('456 Maple Avenue', '67890', '20', '3B', 'Greenville'),
+       ('789 Pine Road', '11223', '30', '4C', 'Rivertown');
+
+
+INSERT INTO sport_complexes (name, description, website, surface, category, latitude, longitude, address_id, open_24_7) VALUES
+('Olympia Arena', 'A large outdoor stadium suitable for various sports, including running and team sports.', 'www.olympiaarena.com', 'GRASS', 'ATHLETICS', 54.361206, 18.658292, 1, FALSE),
+('Aqua Sports Center', 'Indoor aquatic center with Olympic-size pools and diving facilities.', 'www.aquasportscenter.com', 'ARTIFICIAL_TURF', 'SWIMMING', 54.372158, 18.620951, 2, TRUE),
+('Mountain Bike Park', 'Outdoor complex with trails and tracks for mountain biking enthusiasts.', 'www.mountainbikepark.com', 'CLAY', 'STRENGTH_SPORTS', 54.380570, 18.598446, 3, FALSE),
+('Urban Fitness Hub', 'State-of-the-art fitness center with modern equipment and facilities.', 'www.urbanfitnesshub.com', 'WOODEN_FLOOR', 'FITNESS', 54.348629, 18.659222, 4, TRUE),
+('Green Field Soccer Complex', 'Spacious outdoor fields suitable for football and other team sports.', 'www.greenfieldsoccer.com', 'SYNTHETIC_TRACK', 'FOOTBALL', 54.352025, 18.646638, 5, FALSE);
+
+
+INSERT INTO opening_hours (day_of_week, opening_time, closing_time, sport_complex_id)
+VALUES (6, '06:27', '06:51', 2),
+       (2, '08:10', '13:24', 2),
+       (5, '08:21', '23:59', 2),
+       (1, '01:09', '03:54', 2),
+       (6, '18:11', '04:38', 3);
+
+INSERT INTO users (nickname, email, password, salt)
+VALUES
+    ('UserOne', 'userone@example.com', 'password123', 'a1b2c3d4e5f6g7h8'),
+    ('UserTwo', 'usertwo@example.com', 'password456', 'h8g7f6e5d4c3b2a1'),
+    ('UserThree', 'userthree@example.com', 'password789', '1a2b3c4d5e6f7g8h'),
+    ('UserFour', 'userfour@example.com', 'password101', '8h7g6f5e4d3c2b1a'),
+    ('UserFive', 'userfive@example.com', 'password102', '1a1b1c1d1e1f1g1h');
+
+
+
+INSERT INTO reviews (content, sport_complex_id, user_id)
+VALUES
+    ('Great facilities and well-maintained fields.', 1, 1),
+    ('The staff is friendly and the equipment is top-notch.', 2, 2),
+    ('Excellent location for swimming competitions, clean and accessible.', 3, 3),
+    ('The gym has a wide range of equipment and is rarely overcrowded.', 4, 4),
+    ('Perfect for weekend soccer games, the turf is in great condition.', 5, 5);
+
+INSERT INTO events (description, sport_complex_id, start_time, end_time)
+VALUES
+    ('City Crossfit Challenge', 1, '2023-07-15 14:00:00', '2023-07-15 17:00:00'),
+    ('National Gymnastics Competition', 2, '2023-08-20 09:00:00', '2023-08-20 18:00:00'),
+    ('Urban Ice Skating Showdown', 3, '2023-09-10 06:00:00', '2023-09-10 14:00:00'),
+    ('Beach Volleyball Summer Cup', 4,'2023-10-05 10:00:00', '2023-10-08 20:00:00'),
+    ('Extreme Sports Expo 2023', 5, '2023-11-15 17:00:00', '2023-11-15 21:00:00');
+
+INSERT INTO users_events (user_id, event_id) VALUES
+(1, 1),
+(2, 2),
+(3, 3),
+(4, 4),
+(5, 5);

--- a/backend/src/main/java/pl/edu/pja/sportsmap/controller/SportComplexController.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/controller/SportComplexController.java
@@ -1,0 +1,48 @@
+package pl.edu.pja.sportsmap.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import pl.edu.pja.sportsmap.dto.SportComplexSimpleDto;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+import pl.edu.pja.sportsmap.service.EventService;
+import pl.edu.pja.sportsmap.service.OpeningHoursService;
+import pl.edu.pja.sportsmap.service.SportComplexService;
+
+import java.util.List;
+
+@Controller
+@RequestMapping("/sport-complexes")
+public class SportComplexController {
+    private final SportComplexService sportComplexService;
+    private final OpeningHoursService openingHoursService;
+    private final EventService eventService;
+
+    public SportComplexController(SportComplexService sportComplexService, OpeningHoursService openingHoursService, EventService eventService) {
+        this.sportComplexService = sportComplexService;
+        this.openingHoursService = openingHoursService;
+        this.eventService = eventService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<SportComplexSimpleDto>> getAllSportComplexes() {
+        List<SportComplexSimpleDto> sportComplexDtos = sportComplexService.getAllSportComplexes()
+                .stream()
+                .map(this::convertEntityToDto)
+                .toList();
+        return ResponseEntity.ok(sportComplexDtos);
+    }
+
+    private SportComplexSimpleDto convertEntityToDto(SportComplex sportComplex) {
+        return SportComplexSimpleDto.builder()
+                .id(sportComplex.getId())
+                .category(sportComplex.getCategory())
+                .latitude(sportComplex.getLatitude())
+                .longitude(sportComplex.getLongitude())
+                .isOpen(openingHoursService.isSportComplexOpenNow(sportComplex))
+                .isEventNow(eventService.isEventNow(sportComplex))
+                .isEventTomorrow(eventService.isEventTomorrow(sportComplex))
+                .build();
+    }
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/dto/OpeningHoursDto.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/dto/OpeningHoursDto.java
@@ -1,0 +1,6 @@
+package pl.edu.pja.sportsmap.dto;
+
+public class OpeningHoursDto {
+    private TimeRangeDto monday;
+    private TimeRangeDto tuesday;
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/dto/SportComplexSimpleDto.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/dto/SportComplexSimpleDto.java
@@ -1,0 +1,19 @@
+package pl.edu.pja.sportsmap.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import pl.edu.pja.sportsmap.persistence.model.SportComplexCategory;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SportComplexSimpleDto {
+    private Long id;
+    private SportComplexCategory category;
+    private Double latitude;
+    private Double longitude;
+    private boolean isOpen;
+    private boolean isEventNow;
+    private boolean isEventTomorrow;
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/dto/TimeRangeDto.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/dto/TimeRangeDto.java
@@ -1,0 +1,8 @@
+package pl.edu.pja.sportsmap.dto;
+
+import java.time.LocalTime;
+
+public class TimeRangeDto {
+    private LocalTime openTime;
+    private LocalTime closeTime;
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/dao/EventRepository.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/dao/EventRepository.java
@@ -1,7 +1,20 @@
 package pl.edu.pja.sportsmap.persistence.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 import pl.edu.pja.sportsmap.persistence.model.Event;
 
+import java.util.List;
+
+@Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
+    @Query(value = "SELECT * FROM events WHERE NOW() BETWEEN start_time AND end_time AND sport_complex_id = :sportComplexId", nativeQuery = true)
+    List<Event> findCurrentEventsByComplexId(@Param("sportComplexId") Long sportComplexId);
+
+    @Query(value = "SELECT * FROM events " +
+            "WHERE start_time >= CURRENT_DATE + INTERVAL '1 day' AND start_time < CURRENT_DATE + INTERVAL '2 days' " +
+            "AND sport_complex_id = :sportComplexId", nativeQuery = true)
+    List<Event> findEventsStartingNextDayByComplexId(@Param("sportComplexId") Long sportComplexId);
 }

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/dao/OpeningHoursRepository.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/dao/OpeningHoursRepository.java
@@ -3,6 +3,10 @@ package pl.edu.pja.sportsmap.persistence.dao;
 import org.springframework.data.jpa.repository.JpaRepository;
 import pl.edu.pja.sportsmap.persistence.model.OpeningHours;
 
-public interface OpeningHoursRepository extends JpaRepository<OpeningHours, Long> {
+import java.time.DayOfWeek;
+import java.util.List;
 
+public interface OpeningHoursRepository extends JpaRepository<OpeningHours, Long> {
+    List<OpeningHours> findBySportComplexId(Long complexId);
+    OpeningHours getOpeningHoursBySportComplexIdAndAndDayOfWeek(Long sportComplexId, DayOfWeek dayOfWeek);
 }

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/Event.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/Event.java
@@ -2,8 +2,6 @@ package pl.edu.pja.sportsmap.persistence.model;
 
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.util.Date;
@@ -11,7 +9,7 @@ import java.util.Date;
 
 @Entity
 @Table(name = "events")
-@Getter @Setter @NoArgsConstructor @RequiredArgsConstructor
+@Getter @Setter
 public class Event {
 
     @Id
@@ -22,16 +20,12 @@ public class Event {
     private String description;
 
     @ManyToOne
+    @JoinColumn(name = "sport_complex_id")
     private SportComplex sportComplex;
-
-    @Column(name = "category")
-    private String category;
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date startTime;
 
     @Temporal(TemporalType.TIMESTAMP)
     private Date endTime;
-
-
 }

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/OpeningHours.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/OpeningHours.java
@@ -13,6 +13,7 @@ import java.time.DayOfWeek;
 @Getter
 @Setter
 @NoArgsConstructor
+@Table(name = "opening_hours")
 public class OpeningHours {
 
     @Id
@@ -26,9 +27,10 @@ public class OpeningHours {
     private Time closingTime;
 
     @Column
-    @Enumerated
+    @Enumerated(EnumType.ORDINAL)
     private DayOfWeek dayOfWeek;
 
     @ManyToOne
+    @JoinColumn(name = "sport_complex_id")
     private SportComplex sportComplex;
 }

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplex.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplex.java
@@ -26,16 +26,21 @@ public class SportComplex {
     private String website;
 
     @Column
-    private String surface;
+    @Enumerated(EnumType.STRING)
+    private SportComplexSurface surface;
 
     @Column
-    private String category;
+    @Enumerated(EnumType.STRING)
+    private SportComplexCategory category;
 
     @Column
-    private String coordinates;
+    private Double latitude;
 
     @Column
-    private String open247;
+    private Double longitude;
+
+    @Column(name = "open_24_7")
+    private boolean isOpen247;
 
     @ManyToOne
     private Address address;

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplexCategory.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplexCategory.java
@@ -1,0 +1,27 @@
+package pl.edu.pja.sportsmap.persistence.model;
+
+public enum SportComplexCategory {
+    RUNNING,
+    CROSSFIT,
+    FITNESS,
+    GYMNASTICS,
+    BASKETBALL,
+    BOWLING,
+    ATHLETICS,
+    ICE_SKATING,
+    FOOTBALL,
+    HANDBALL,
+    SWIMMING,
+    VOLLEYBALL,
+    BEACH_VOLLEYBALL,
+    EXTREME_SPORTS,
+    STRENGTH_SPORTS,
+    MARTIAL_ARTS,
+    CHESS,
+    DANCE,
+    TABLE_TENNIS,
+    TENNIS,
+    CLIMBING
+}
+
+

--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplexSurface.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplexSurface.java
@@ -1,0 +1,14 @@
+package pl.edu.pja.sportsmap.persistence.model;
+
+public enum SportComplexSurface {
+    GRASS,
+    ARTIFICIAL_TURF,
+    CLAY,
+    HARD_COURT,
+    WOODEN_FLOOR,
+    SYNTHETIC_TRACK,
+    ASPHALT,
+    SAND,
+    ICE,
+    ACRYLIC
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/service/EventService.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/service/EventService.java
@@ -1,0 +1,22 @@
+package pl.edu.pja.sportsmap.service;
+
+import org.springframework.stereotype.Service;
+import pl.edu.pja.sportsmap.persistence.dao.EventRepository;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+
+@Service
+public class EventService {
+    private final EventRepository eventRepository;
+
+    public EventService(EventRepository eventRepository) {
+        this.eventRepository = eventRepository;
+    }
+
+    public boolean isEventNow(SportComplex sportComplex) {
+        return !eventRepository.findCurrentEventsByComplexId(sportComplex.getId()).isEmpty();
+    }
+
+    public boolean isEventTomorrow(SportComplex sportComplex) {
+        return !eventRepository.findEventsStartingNextDayByComplexId(sportComplex.getId()).isEmpty();
+    }
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/service/OpeningHoursService.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/service/OpeningHoursService.java
@@ -1,0 +1,45 @@
+package pl.edu.pja.sportsmap.service;
+
+import org.springframework.stereotype.Service;
+import pl.edu.pja.sportsmap.persistence.dao.OpeningHoursRepository;
+import pl.edu.pja.sportsmap.persistence.model.OpeningHours;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Service
+public class OpeningHoursService {
+    public static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm:ss");
+    private final OpeningHoursRepository openingHoursRepository;
+
+    public OpeningHoursService(OpeningHoursRepository openingHoursRepository) {
+        this.openingHoursRepository = openingHoursRepository;
+    }
+
+    public List<OpeningHours> getOpeningHours(Long complexId) {
+        return openingHoursRepository.findBySportComplexId(complexId);
+    }
+
+    public boolean isSportComplexOpenNow(SportComplex sportComplex) {
+        if (sportComplex.isOpen247()) {
+            return true;
+        }
+
+        LocalDateTime now = LocalDateTime.now();
+        DayOfWeek dayOfWeek = now.getDayOfWeek();
+
+        OpeningHours openingHours = openingHoursRepository
+                .getOpeningHoursBySportComplexIdAndAndDayOfWeek(sportComplex.getId(), dayOfWeek);
+
+        if (openingHours == null || openingHours.getOpeningTime() == null || openingHours.getClosingTime() == null) {
+            return false;
+        }
+
+        return now.isAfter(LocalDateTime.from(openingHours.getOpeningTime().toLocalTime().atDate(LocalDate.now()))) &&
+                now.isBefore(LocalDateTime.from(openingHours.getClosingTime().toLocalTime().atDate(LocalDate.now())));
+    }
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/service/SportComplexAddressService.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/service/SportComplexAddressService.java
@@ -1,0 +1,11 @@
+package pl.edu.pja.sportsmap.service;
+
+import pl.edu.pja.sportsmap.persistence.dao.AddressRepository;
+
+public class SportComplexAddressService {
+    private final AddressRepository addressRepository;
+
+    public SportComplexAddressService(AddressRepository addressRepository) {
+        this.addressRepository = addressRepository;
+    }
+}

--- a/backend/src/main/java/pl/edu/pja/sportsmap/service/SportComplexService.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/service/SportComplexService.java
@@ -1,0 +1,20 @@
+package pl.edu.pja.sportsmap.service;
+
+import org.springframework.stereotype.Service;
+import pl.edu.pja.sportsmap.persistence.dao.SportComplexRepository;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+
+import java.util.List;
+
+@Service
+public class SportComplexService {
+    private final SportComplexRepository sportComplexRepository;
+
+    public SportComplexService(SportComplexRepository sportComplexRepository) {
+        this.sportComplexRepository = sportComplexRepository;
+    }
+
+    public List<SportComplex> getAllSportComplexes() {
+        return sportComplexRepository.findAll();
+    }
+}

--- a/backend/src/test/java/pl/edu/pja/sportsmap/service/EventServiceTest.java
+++ b/backend/src/test/java/pl/edu/pja/sportsmap/service/EventServiceTest.java
@@ -1,0 +1,65 @@
+package pl.edu.pja.sportsmap.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pja.sportsmap.persistence.dao.EventRepository;
+import pl.edu.pja.sportsmap.persistence.model.Event;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+    @Mock
+    private EventRepository eventRepository;
+    @InjectMocks
+    private EventService eventService;
+
+    @Test
+    void isEventShouldReturnTrue() {
+        // given
+        when(eventRepository.findCurrentEventsByComplexId(any())).thenReturn(List.of(new Event()));
+        // when
+        boolean eventNow = eventService.isEventNow(new SportComplex());
+        // then
+        assertTrue(eventNow);
+    }
+
+    @Test
+    void isEventShouldReturnFalse() {
+        // given
+        when(eventRepository.findCurrentEventsByComplexId(any())).thenReturn(List.of());
+        // when
+        boolean eventNow = eventService.isEventNow(new SportComplex());
+        // then
+        assertFalse(eventNow);
+    }
+
+    @Test
+    void isEventTomorrowShouldReturnTrue() {
+        // given
+        when(eventRepository.findEventsStartingNextDayByComplexId(any())).thenReturn(List.of(new Event()));
+        // when
+        boolean eventTomorrow = eventService.isEventTomorrow(new SportComplex());
+        // then
+        assertTrue(eventTomorrow);
+    }
+
+    @Test
+    void isEventTomorrowShouldReturnFalse() {
+        // given
+        when(eventRepository.findEventsStartingNextDayByComplexId(any())).thenReturn(List.of());
+        // when
+        boolean eventTomorrow = eventService.isEventTomorrow(new SportComplex());
+        // then
+        assertFalse(eventTomorrow);
+    }
+}

--- a/backend/src/test/java/pl/edu/pja/sportsmap/service/OpeningHoursServiceTest.java
+++ b/backend/src/test/java/pl/edu/pja/sportsmap/service/OpeningHoursServiceTest.java
@@ -1,0 +1,59 @@
+package pl.edu.pja.sportsmap.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import pl.edu.pja.sportsmap.persistence.dao.OpeningHoursRepository;
+import pl.edu.pja.sportsmap.persistence.dao.SportComplexRepository;
+import pl.edu.pja.sportsmap.persistence.model.OpeningHours;
+import pl.edu.pja.sportsmap.persistence.model.SportComplex;
+
+import java.sql.Time;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static pl.edu.pja.sportsmap.service.OpeningHoursService.formatter;
+
+@ExtendWith(MockitoExtension.class)
+class OpeningHoursServiceTest {
+    @Mock
+    OpeningHoursRepository openingHoursRepository;
+    @InjectMocks
+    OpeningHoursService openingHoursService;
+
+    @Test
+    void isSportComplexOpenShouldReturnTrueWhenHoursAreInGivenTimeFrame() {
+        // given
+        Time openingTime = Time.valueOf(formatter.format(LocalTime.now().minusSeconds(5)));
+        Time closingTime = Time.valueOf(formatter.format(LocalTime.now().plusSeconds(5)));
+        OpeningHours openingHours = new OpeningHours();
+        openingHours.setOpeningTime(openingTime);
+        openingHours.setClosingTime(closingTime);
+
+        when(openingHoursRepository.getOpeningHoursBySportComplexIdAndAndDayOfWeek(any(), any())).thenReturn(openingHours);
+        // when
+        boolean sportComplexOpenNow = openingHoursService.isSportComplexOpenNow(new SportComplex());
+        // then
+        assertTrue(sportComplexOpenNow);
+    }
+
+    @Test
+    void isSportComplexOpenShouldReturnFalseWhenHoursAreInGivenTimeFrame() {
+        // given
+        Time openingTime = Time.valueOf(formatter.format(LocalTime.now().plusSeconds(5)));
+        Time closingTime = Time.valueOf(formatter.format(LocalTime.now().plusSeconds(10)));
+        OpeningHours openingHours = new OpeningHours();
+        openingHours.setOpeningTime(openingTime);
+        openingHours.setClosingTime(closingTime);
+        when(openingHoursRepository.getOpeningHoursBySportComplexIdAndAndDayOfWeek(any(), any())).thenReturn(openingHours);
+        // when
+        boolean sportComplexOpenNow = openingHoursService.isSportComplexOpenNow(new SportComplex());
+        // then
+        assertFalse(sportComplexOpenNow);
+    }
+}


### PR DESCRIPTION
Obecnie tak wygląda przykładowy response:
```
[
    {
        "id": 1,
        "category": "FOOTBALL",
        "latitude": 40.712776,
        "longitude": -74.005974,
        "eventNow": true,
        "eventTomorrow": false,
        "open": false
    },
    {
        "id": 2,
        "category": "SWIMMING",
        "latitude": 34.052235,
        "longitude": -118.243683,
        "eventNow": false,
        "eventTomorrow": true,
        "open": true
    },
    {
        "id": 3,
        "category": "CYCLING",
        "latitude": 51.507351,
        "longitude": -0.127758,
        "eventNow": false,
        "eventTomorrow": false,
        "open": false
    },
    {
        "id": 4,
        "category": "GYM",
        "latitude": 48.856613,
        "longitude": 2.352222,
        "eventNow": false,
        "eventTomorrow": false,
        "open": true
    },
    {
        "id": 5,
        "category": "FOOTBALL",
        "latitude": 41.902782,
        "longitude": 12.496366,
        "eventNow": false,
        "eventTomorrow": false,
        "open": false
    }
]
```
Nazwy enumów dla category jeszcze zmienie, tak aby były takie same jak te wysłane przez @Wopliieee. Otwieram jako draft, bo jest jeszcze klika test case'ów które chciałbym dopisać razem z testami integracyjnymi, ale każdy feedback mile widziany :)