### PR TITLE
fix name collisions between database and classes

### DIFF
--- a/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplex.java
+++ b/backend/src/main/java/pl/edu/pja/sportsmap/persistence/model/SportComplex.java
@@ -48,6 +48,6 @@ public class SportComplex {
     @Column
     private String photo;
 
-    @Column
+    @Column(name = "phone_number")
     private String phoneNumber;
 }


### PR DESCRIPTION
fix the problem with new column - "phone_number" in sport_complexes table. 
In sql the name was "phone_number" and in java it was "phoneNumber"

fixed by adding name attribute to @Column in SportComplex.java
  @Column(name = "phone_number")
    private String phoneNumber;